### PR TITLE
fix: package name must match import

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -1,4 +1,4 @@
-package slogmeld
+package meld
 
 import (
 	"context"

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,4 +1,4 @@
-package slogmeld
+package meld
 
 import (
 	"bytes"


### PR DESCRIPTION
Package name `slogmeld` does not match with import `meld` from `snqk.dev/slog/meld`, causing confusion.

This PR introduces a breaking change to update the package name to `meld`.