### PR TITLE
docs: improve readme + add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported Versions
+
+`go.mod` will be updated to the next supported `go1.XX.0` version on a best-effort basis. No other dependencies are used.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it responsibly by emailing [me@snqk.dev](mailto:me@snqk.dev).
+
+### Secure Correspondence
+
+My GnuPG Public Key is also accessible at [https://gpg.sarthak.sh](https://gpg.sarthak.sh). For secure encrypted disclosure, you may email [secure@snqk.dev](mailto:secure@snqk.dev) instead.
+
+## Announcements
+
+Notable news & releases for this project will be shared via the [Announcement](https://github.com/snqk/slog-meld/discussions/4) discussions page.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module snqk.dev/slog/meld
 
-go 1.22
+go 1.22.0
 
 require github.com/stretchr/testify v1.9.0
 


### PR DESCRIPTION
Provide clearer examples by comparing outputs with `log/slog` and other libraries.

Miscellaneous improvements to README.md.

Add a SECURITY.md for responsible disclosure.

