### PR TITLE
feat/concurrency: remove unnecessary use of mutex

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -14,7 +14,7 @@ type handler struct {
 }
 
 // NewHandler returns a slog.Handler which melds (joins) older slog.Attr(s) with newer updates, making it a mutable slog.Handler.
-// It is thread-safe, using a sync.RWMutex.
+// It is thread-safe by immutability; handler state is never updated in-place after creation.
 // It is recursive; merging slog.KindGroup, and replacing / updating all other types as appropriate.
 // It is ordered; slog.Attr(s) configured first will appear in order. Replacing an attribute does not change its position in the order.
 func NewHandler(next slog.Handler) slog.Handler {

--- a/internal/tree/group.go
+++ b/internal/tree/group.go
@@ -2,11 +2,9 @@ package tree
 
 import (
 	"log/slog"
-	"sync"
 )
 
 type Group struct {
-	m  sync.RWMutex
 	vs []*value
 }
 
@@ -16,9 +14,6 @@ func (g *Group) LogValue() slog.Value {
 
 func (g *Group) Clone() *Group {
 	n := &Group{vs: make([]*value, len(g.vs))}
-
-	g.m.RLock()
-	defer g.m.RUnlock()
 
 	for i, v := range g.vs {
 		n.vs[i] = v.clone()
@@ -30,9 +25,6 @@ func (g *Group) Clone() *Group {
 func (g *Group) Render() []slog.Attr {
 	out := make([]slog.Attr, len(g.vs))
 
-	g.m.RLock()
-	defer g.m.RUnlock()
-
 	for i, v := range g.vs {
 		out[i] = slog.Attr{Key: v.name, Value: v.LogValue()}
 	}
@@ -41,9 +33,6 @@ func (g *Group) Render() []slog.Attr {
 }
 
 func (g *Group) Merge(stack []string, attrs ...slog.Attr) {
-	g.m.Lock()
-	defer g.m.Unlock()
-
 	for i := range attrs {
 		merge(g, stack, attrs[i])
 	}


### PR DESCRIPTION
Removes the unnecessary use of sync.RWMutex required for internal merging of slog.Attr(s), as all merge operations are immutable & only occur upon constructing the tree. Creation of a new tree occurs by merging the attributes of an older tree + the updated attributes.